### PR TITLE
Remove printings to stdout

### DIFF
--- a/configor.go
+++ b/configor.go
@@ -66,10 +66,7 @@ func getConfigurations(files ...string) []string {
 		// check example configuration
 		if !foundFile {
 			if example, err := getConfigurationWithENV(file, "example"); err == nil {
-				fmt.Printf("Failed to find configuration %v, using example file %v\n", file, example)
 				results = append(results, example)
-			} else {
-				fmt.Printf("Failed to find configuration %v\n", file)
 			}
 		}
 	}


### PR DESCRIPTION
Hi, I've noticed that package writes an error messages to stdout, I think it's
wrong behavior and third-party library should not print anything to stdout.
