### PR TITLE
Improve Error Messaging

### DIFF
--- a/configor.go
+++ b/configor.go
@@ -131,7 +131,8 @@ func processTags(config interface{}, prefix ...string) error {
 				}
 			} else if fieldStruct.Tag.Get("required") == "true" {
 				// set configuration has value if it is required
-				return errors.New(fieldStruct.Name + " is required, but blank")
+				path := append(prefix, fieldStruct.Name)
+				return errors.New(strings.Join(path, ".") + " is required, but blank")
 			}
 		}
 

--- a/configor.go
+++ b/configor.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/hashicorp/go-multierror"
 
 	"gopkg.in/yaml.v2"
 )
@@ -104,6 +105,8 @@ func processTags(config interface{}, prefix ...string) error {
 		return errors.New("invalid config, should be struct")
 	}
 
+	var errs *multierror.Error
+
 	configType := configValue.Type()
 	for i := 0; i < configType.NumField(); i++ {
 		fieldStruct := configType.Field(i)
@@ -118,7 +121,7 @@ func processTags(config interface{}, prefix ...string) error {
 		if envName != "" {
 			if value := os.Getenv(envName); value != "" {
 				if err := yaml.Unmarshal([]byte(value), field.Addr().Interface()); err != nil {
-					return err
+					errs = multierror.Append(errs, err)
 				}
 			}
 		}
@@ -127,12 +130,13 @@ func processTags(config interface{}, prefix ...string) error {
 			// set default configuration if is blank
 			if value := fieldStruct.Tag.Get("default"); value != "" {
 				if err := yaml.Unmarshal([]byte(value), field.Addr().Interface()); err != nil {
-					return err
+					errs = multierror.Append(errs, err)
 				}
 			} else if fieldStruct.Tag.Get("required") == "true" {
 				// set configuration has value if it is required
 				path := append(prefix, fieldStruct.Name)
-				return errors.New(strings.Join(path, ".") + " is required, but blank")
+				err := errors.New(strings.Join(path, ".") + " is required, but blank")
+				errs = multierror.Append(errs, err)
 			}
 		}
 
@@ -142,7 +146,7 @@ func processTags(config interface{}, prefix ...string) error {
 
 		if field.Kind() == reflect.Struct {
 			if err := processTags(field.Addr().Interface(), append(prefix, fieldStruct.Name)...); err != nil {
-				return err
+				errs = multierror.Append(errs, err)
 			}
 		}
 
@@ -151,13 +155,13 @@ func processTags(config interface{}, prefix ...string) error {
 			for i := 0; i < length; i++ {
 				if reflect.Indirect(field.Index(i)).Kind() == reflect.Struct {
 					if err := processTags(field.Index(i).Addr().Interface(), append(prefix, fieldStruct.Name, fmt.Sprintf("%d", i))...); err != nil {
-						return err
+						errs = multierror.Append(errs, err)
 					}
 				}
 			}
 		}
 	}
-	return nil
+	return errs.ErrorOrNil()
 }
 
 func load(config interface{}, file string) error {

--- a/configor_test.go
+++ b/configor_test.go
@@ -337,6 +337,14 @@ func TestErrorIncludesPath(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Multiple fields
+			path: "B",
+			strukt: &struct {
+				A string `required:"true"`
+				B string `required:"true"`
+			}{},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
This includes two changes:

1. Include full path to struct when a required field is missing. This solves the problem when you have fields in different structs with the same. If either is `required:"true"` but missing/blank, the error is just "<field name> is required, but blank", and you have to dig around to find out *which* of the fields is blank.
2. Try to load *the whole config struct* instead of giving up at the first error. This means, for N missing fields, you don't have to: 1) fix first error, 2) re-run `Load` to discover the next error, 3) repeat. Instead, Configor will tell you "all" of the errors at once.