### PR TITLE
Return error on unmatched keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ contacts:
 configor.Load(&Config, "application.yml", "database.json")
 ```
 
+* Return error on unmatched keys
+
+Return an error on finding keys in the config file that do not match any fields in the config struct.
+In the example below, an error will be returned if config.toml contains keys that do not match any fields in the ConfigStruct struct.
+If ErrorOnUnmatchedKeys is not set, it defaults to false.
+Note that this is currently only supported for toml and yaml files. ErrorOnUnmatchedKeys will be ignored for json files. This may change in the future when the json library adds support for this [https://github.com/golang/go/issues/15314].
+
+```go
+err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&ConfigStruct, "config.toml")
+```
+
 * Load configuration by environment
 
 Use `CONFIGOR_ENV` to set environment, if `CONFIGOR_ENV` not set, environment will be `development` by default, and it will be `test` when running tests with `go test`

--- a/configor.go
+++ b/configor.go
@@ -10,8 +10,9 @@ type Configor struct {
 }
 
 type Config struct {
-	Environment string
-	ENVPrefix   string
+	Environment          string
+	ENVPrefix            string
+	ErrorOnUnmatchedKeys bool
 }
 
 // New initialize a Configor
@@ -38,10 +39,17 @@ func (configor *Configor) GetEnvironment() string {
 	return configor.Environment
 }
 
+// GetErrorOnUnmatchedKeys returns a boolean indicating if an error should be
+// thrown if there are keys in the config file that do not correspond to the
+// config struct
+func (configor *Configor) GetErrorOnUnmatchedKeys() bool {
+	return configor.ErrorOnUnmatchedKeys
+}
+
 // Load will unmarshal configurations to struct from files that you provide
 func (configor *Configor) Load(config interface{}, files ...string) error {
 	for _, file := range configor.getConfigurationFiles(files...) {
-		if err := processFile(config, file); err != nil {
+		if err := processFile(config, file, configor.GetErrorOnUnmatchedKeys()); err != nil {
 			return err
 		}
 	}

--- a/configor.go
+++ b/configor.go
@@ -10,8 +10,12 @@ type Configor struct {
 }
 
 type Config struct {
-	Environment          string
-	ENVPrefix            string
+	Environment string
+	ENVPrefix   string
+
+	// Supported only for toml and yaml files.
+	// json does not currently support this: https://github.com/golang/go/issues/15314
+	// This setting will be ignored for json files.
 	ErrorOnUnmatchedKeys bool
 }
 

--- a/configor_test.go
+++ b/configor_test.go
@@ -233,6 +233,68 @@ func TestUnmatchedTomlValueInConfigFileNoError(t *testing.T) {
 	}
 }
 
+func TestUnmatchedYamlValueInConfigFile(t *testing.T) {
+	type configStruct struct {
+		Name string
+	}
+	type configFile struct {
+		Name string
+		Test string
+	}
+	config := configFile{Name: "test", Test: "ATest"}
+
+	file, err := ioutil.TempFile("/tmp", "configor")
+	if err != nil {
+		t.Fatal("Could not create temp file")
+	}
+
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if data, err := yaml.Marshal(config); err == nil {
+		file.WriteString(string(data))
+
+		var result configStruct
+		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
+			t.Errorf("Should get error when loading configuration with extra keys")
+		}
+
+	} else {
+		t.Errorf("failed to marshal config")
+	}
+}
+
+func TestUnmatchedYamlValueInConfigFileNoError(t *testing.T) {
+	type configStruct struct {
+		Name string
+	}
+	type configFile struct {
+		Name string
+		Test string
+	}
+	config := configFile{Name: "test", Test: "ATest"}
+
+	file, err := ioutil.TempFile("/tmp", "configor")
+	if err != nil {
+		t.Fatal("Could not create temp file")
+	}
+
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if data, err := yaml.Marshal(config); err == nil {
+		file.WriteString(string(data))
+
+		var result configStruct
+		if err := configor.New(&configor.Config{}).Load(&result, file.Name()); err != nil {
+			t.Errorf("Should NOT get error when loading configuration with extra keys")
+		}
+
+	} else {
+		t.Errorf("failed to marshal config")
+	}
+}
+
 func TestLoadConfigurationByEnvironment(t *testing.T) {
 	config := generateDefaultConfig()
 	config2 := struct {

--- a/configor_test.go
+++ b/configor_test.go
@@ -175,7 +175,7 @@ func TestMissingRequiredValue(t *testing.T) {
 	}
 }
 
-func TestUnmatchedTomlValueInConfigFile(t *testing.T) {
+func TestUnmatchedKeyInTomlConfigFile(t *testing.T) {
 	type configStruct struct {
 		Name string
 	}
@@ -195,6 +195,12 @@ func TestUnmatchedTomlValueInConfigFile(t *testing.T) {
 	if err := toml.NewEncoder(file).Encode(config); err == nil {
 
 		var result configStruct
+
+		// Do not return error when there are unmatched keys but ErrorOnUnmatchedKeys is false
+		if err := configor.New(&configor.Config{}).Load(&result, file.Name()); err != nil {
+			t.Errorf("Should NOT get error when loading configuration with extra keys")
+		}
+
 		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
 			t.Errorf("Should get error when loading configuration with extra keys")
 		}
@@ -204,36 +210,7 @@ func TestUnmatchedTomlValueInConfigFile(t *testing.T) {
 	}
 }
 
-func TestUnmatchedTomlValueInConfigFileNoError(t *testing.T) {
-	type configStruct struct {
-		Name string
-	}
-	type configFile struct {
-		Name string
-		Test string
-	}
-	config := configFile{Name: "test", Test: "ATest"}
-
-	file, err := ioutil.TempFile("/tmp", "configor")
-	if err != nil {
-		t.Fatal("Could not create temp file")
-	}
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	if err := toml.NewEncoder(file).Encode(config); err == nil {
-
-		var result configStruct
-		if err := configor.New(&configor.Config{}).Load(&result, file.Name()); err != nil {
-			t.Errorf("Should NOT get error when loading configuration with extra keys")
-		}
-
-	} else {
-		t.Errorf("failed to marshal config")
-	}
-}
-
-func TestUnmatchedYamlValueInConfigFile(t *testing.T) {
+func TestUnmatchedKeyInYamlConfigFile(t *testing.T) {
 	type configStruct struct {
 		Name string
 	}
@@ -255,39 +232,14 @@ func TestUnmatchedYamlValueInConfigFile(t *testing.T) {
 		file.WriteString(string(data))
 
 		var result configStruct
-		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
-			t.Errorf("Should get error when loading configuration with extra keys")
-		}
 
-	} else {
-		t.Errorf("failed to marshal config")
-	}
-}
-
-func TestUnmatchedYamlValueInConfigFileNoError(t *testing.T) {
-	type configStruct struct {
-		Name string
-	}
-	type configFile struct {
-		Name string
-		Test string
-	}
-	config := configFile{Name: "test", Test: "ATest"}
-
-	file, err := ioutil.TempFile("/tmp", "configor")
-	if err != nil {
-		t.Fatal("Could not create temp file")
-	}
-
-	defer os.Remove(file.Name())
-	defer file.Close()
-
-	if data, err := yaml.Marshal(config); err == nil {
-		file.WriteString(string(data))
-
-		var result configStruct
+		// Do not return error when there are unmatched keys but ErrorOnUnmatchedKeys is false
 		if err := configor.New(&configor.Config{}).Load(&result, file.Name()); err != nil {
 			t.Errorf("Should NOT get error when loading configuration with extra keys")
+		}
+
+		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
+			t.Errorf("Should get error when loading configuration with extra keys")
 		}
 
 	} else {

--- a/configor_test.go
+++ b/configor_test.go
@@ -175,6 +175,35 @@ func TestMissingRequiredValue(t *testing.T) {
 	}
 }
 
+func TestUnmatchedValueInConfigFile(t *testing.T) {
+	type configStruct struct {
+		Name string
+	}
+	type configFile struct {
+		Name string
+		Test string
+	}
+	config := configFile{Name: "test", Test: "ATest"}
+
+	file, err := ioutil.TempFile("/tmp", "configor")
+	if err != nil {
+		t.Fatal("Could not create temp file")
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := toml.NewEncoder(file).Encode(config); err == nil {
+
+		var result configStruct
+		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
+			t.Errorf("Should get error when loading configuration with extra keys")
+		}
+
+	} else {
+		t.Errorf("failed to marshal config")
+	}
+}
+
 func TestLoadConfigurationByEnvironment(t *testing.T) {
 	config := generateDefaultConfig()
 	config2 := struct {

--- a/configor_test.go
+++ b/configor_test.go
@@ -175,7 +175,7 @@ func TestMissingRequiredValue(t *testing.T) {
 	}
 }
 
-func TestUnmatchedValueInConfigFile(t *testing.T) {
+func TestUnmatchedTomlValueInConfigFile(t *testing.T) {
 	type configStruct struct {
 		Name string
 	}
@@ -197,6 +197,35 @@ func TestUnmatchedValueInConfigFile(t *testing.T) {
 		var result configStruct
 		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, file.Name()); err == nil {
 			t.Errorf("Should get error when loading configuration with extra keys")
+		}
+
+	} else {
+		t.Errorf("failed to marshal config")
+	}
+}
+
+func TestUnmatchedTomlValueInConfigFileNoError(t *testing.T) {
+	type configStruct struct {
+		Name string
+	}
+	type configFile struct {
+		Name string
+		Test string
+	}
+	config := configFile{Name: "test", Test: "ATest"}
+
+	file, err := ioutil.TempFile("/tmp", "configor")
+	if err != nil {
+		t.Fatal("Could not create temp file")
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if err := toml.NewEncoder(file).Encode(config); err == nil {
+
+		var result configStruct
+		if err := configor.New(&configor.Config{}).Load(&result, file.Name()); err != nil {
+			t.Errorf("Should NOT get error when loading configuration with extra keys")
 		}
 
 	} else {


### PR DESCRIPTION
Return an error when there are keys in the config file that do not match any fields in the Config struct.

This behavior will be controlled by a boolean field called `ErrorOnUnmatchedKeys` in the Configor.Config struct. It will default to false. If set to true, an error will be returned if the config file contains an unmatched key.

It is supported only for yaml and toml files. Note that I changed it to use yaml.v2 instead of yaml.v1.
I can add support for json files once the json library adds support for this.