### PR TITLE
Add support for using the ErrorOnUnmatchedKeys setting with json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ configor.Load(&Config, "application.yml", "database.json")
 Return an error on finding keys in the config file that do not match any fields in the config struct.
 In the example below, an error will be returned if config.toml contains keys that do not match any fields in the ConfigStruct struct.
 If ErrorOnUnmatchedKeys is not set, it defaults to false.
-Note that this is currently only supported for toml and yaml files. ErrorOnUnmatchedKeys will be ignored for json files. This may change in the future when the json library adds support for this [https://github.com/golang/go/issues/15314].
+
+Note that for json files, setting ErrorOnUnmatchedKeys to true will have an effect only if using go 1.10 or later.
 
 ```go
 err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&ConfigStruct, "config.toml")

--- a/configor.go
+++ b/configor.go
@@ -16,9 +16,9 @@ type Config struct {
 	Debug       bool
 	Verbose     bool
 
-	// Supported only for toml and yaml files.
-	// json does not currently support this: https://github.com/golang/go/issues/15314
-	// This setting will be ignored for json files.
+	// In case of json files, this field will be used only when compiled with
+	// go 1.10 or later.
+	// This field will be ignored when compiled with go versions lower than 1.10.
 	ErrorOnUnmatchedKeys bool
 }
 

--- a/configor.go
+++ b/configor.go
@@ -46,7 +46,7 @@ func (configor *Configor) GetEnvironment() string {
 			return env
 		}
 
-		if isTest, _ := regexp.MatchString("/_test/", os.Args[0]); isTest {
+		if isTest, _ := regexp.MatchString(".test", os.Args[0]); isTest {
 			return "test"
 		}
 

--- a/unmarshal_json_1_10.go
+++ b/unmarshal_json_1_10.go
@@ -1,0 +1,28 @@
+// +build go1.10
+
+package configor
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// unmarshalJSON unmarshals the given data into the config interface.
+// If the errorOnUnmatchedKeys boolean is true, an error will be returned if there
+// are keys in the data that do not match fields in the config interface.
+func unmarshalJSON(data []byte, config interface{}, errorOnUnmatchedKeys bool) error {
+	reader := strings.NewReader(string(data))
+	decoder := json.NewDecoder(reader)
+
+	if errorOnUnmatchedKeys {
+		decoder.DisallowUnknownFields()
+	}
+
+	err := decoder.Decode(config)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+
+}

--- a/unmarshal_json_1_10_test.go
+++ b/unmarshal_json_1_10_test.go
@@ -1,0 +1,74 @@
+// +build go1.10
+
+package configor_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jinzhu/configor"
+)
+
+func TestUnmatchedKeyInJsonConfigFile(t *testing.T) {
+	type configStruct struct {
+		Name string
+	}
+	type configFile struct {
+		Name string
+		Test string
+	}
+	config := configFile{Name: "test", Test: "ATest"}
+
+	file, err := ioutil.TempFile("/tmp", "configor")
+	if err != nil {
+		t.Fatal("Could not create temp file")
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	filename := file.Name()
+
+	if err := json.NewEncoder(file).Encode(config); err == nil {
+
+		var result configStruct
+
+		// Do not return error when there are unmatched keys but ErrorOnUnmatchedKeys is false
+		if err := configor.New(&configor.Config{}).Load(&result, filename); err != nil {
+			t.Errorf("Should NOT get error when loading configuration with extra keys. Error: %v", err)
+		}
+
+		// Return an error when there are unmatched keys and ErrorOnUnmatchedKeys is true
+		if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, filename); err == nil || !strings.Contains(err.Error(), "json: unknown field") {
+
+			t.Errorf("Should get unknown field error when loading configuration with extra keys. Instead got error: %v", err)
+		}
+
+	} else {
+		t.Errorf("failed to marshal config")
+	}
+
+	// Add .json to the file name and test
+	err = os.Rename(file.Name(), file.Name()+".json")
+	if err != nil {
+		t.Errorf("Could not add suffix to file")
+	}
+	filename = file.Name() + ".json"
+	defer os.Remove(filename)
+
+	var result configStruct
+
+	// Do not return error when there are unmatched keys but ErrorOnUnmatchedKeys is false
+	if err := configor.New(&configor.Config{}).Load(&result, filename); err != nil {
+		t.Errorf("Should NOT get error when loading configuration with extra keys. Error: %v", err)
+	}
+
+	// Return an error when there are unmatched keys and ErrorOnUnmatchedKeys is true
+	if err := configor.New(&configor.Config{ErrorOnUnmatchedKeys: true}).Load(&result, filename); err == nil || !strings.Contains(err.Error(), "json: unknown field") {
+
+		t.Errorf("Should get unknown field error when loading configuration with extra keys. Instead got error: %v", err)
+	}
+
+}

--- a/unmarshal_json_1_9.go
+++ b/unmarshal_json_1_9.go
@@ -1,0 +1,18 @@
+// +build !go1.10
+
+package configor
+
+import (
+	"encoding/json"
+)
+
+// unmarshalJSON unmarshals the given data into the config interface.
+// The errorOnUnmatchedKeys boolean is ignored since the json library only has
+// support for that feature from go 1.10 onwards.
+// If there are any keys in the data that do not match fields in the config
+// interface, they will be silently ignored.
+func unmarshalJSON(data []byte, config interface{}, errorOnUnmatchedKeys bool) error {
+
+	return json.Unmarshal(data, &config)
+
+}

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package configor
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -105,7 +104,7 @@ func processFile(config interface{}, file string, errorOnUnmatchedKeys bool) err
 	case strings.HasSuffix(file, ".toml"):
 		return unmarshalToml(data, config, errorOnUnmatchedKeys)
 	case strings.HasSuffix(file, ".json"):
-		return json.Unmarshal(data, config)
+		return unmarshalJSON(data, config, errorOnUnmatchedKeys)
 	default:
 
 		if err := unmarshalToml(data, config, errorOnUnmatchedKeys); err == nil {
@@ -114,8 +113,10 @@ func processFile(config interface{}, file string, errorOnUnmatchedKeys bool) err
 			return errUnmatchedKeys
 		}
 
-		if json.Unmarshal(data, config) == nil {
+		if err := unmarshalJSON(data, config, errorOnUnmatchedKeys); err == nil {
 			return nil
+		} else if strings.Contains(err.Error(), "json: unknown field") {
+			return err
 		}
 
 		var yamlError error


### PR DESCRIPTION
go 1.10 added support for returning an error when decoding a json file that has keys which do not match any field in the struct. [https://github.com/golang/go/issues/15314]