### PR TITLE
Fixed cases where configValue is a pointer

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -190,7 +190,11 @@ func getPrefixForStruct(prefixes []string, fieldStruct *reflect.StructField) []s
 func (configor *Configor) processDefaults(config interface{}) error {
 	configValue := reflect.Indirect(reflect.ValueOf(config))
 	if configValue.Kind() != reflect.Struct {
-		return errors.New("invalid config, should be struct")
+		if configValue.Kind() == reflect.Ptr && configValue.Elem().Kind() == reflect.Struct {
+			configValue = configValue.Elem()
+		} else {
+			return errors.New("invalid config, should be struct")
+		}
 	}
 
 	configType := configValue.Type()
@@ -239,7 +243,11 @@ func (configor *Configor) processDefaults(config interface{}) error {
 func (configor *Configor) processTags(config interface{}, prefixes ...string) error {
 	configValue := reflect.Indirect(reflect.ValueOf(config))
 	if configValue.Kind() != reflect.Struct {
-		return errors.New("invalid config, should be struct")
+		if configValue.Kind() == reflect.Ptr && configValue.Elem().Kind() == reflect.Struct {
+			configValue = configValue.Elem()
+		} else {
+			return errors.New("invalid config, should be struct")
+		}
 	}
 
 	configType := configValue.Type()


### PR DESCRIPTION
When we have a config struct like this
```
type Config struct {
   Name string
   Infos []*Info
}

type Info struct {
  Info1 string
  Info2 string
}
```
configor will show an error of `invalid config, should be struct`