### PR TITLE
Fix default value in slices

### DIFF
--- a/configor_test.go
+++ b/configor_test.go
@@ -17,20 +17,21 @@ type Anonymous struct {
 }
 
 type testConfig struct {
-	APPName string `default:"configor" json:",omitempty"`
+	APPName string `default:"configor" json:"-"`
 	Hosts   []string
 
 	DB struct {
 		Name     string
 		User     string `default:"root"`
 		Password string `required:"true" env:"DBPassword"`
-		Port     uint   `default:"3306" json:",omitempty"`
-		SSL      bool   `default:"true" json:",omitempty"`
+		Port     uint   `default:"3306" json:"-"`
+		SSL      bool   `default:"true" json:"-"`
 	}
 
 	Contacts []struct {
-		Name  string
-		Email string `required:"true"`
+		Name   string
+		Email  string `required:"true"`
+		Active bool   `default:"true" json:"-"`
 	}
 
 	Anonymous `anonymous:"true"`
@@ -46,8 +47,8 @@ func generateDefaultConfig() testConfig {
 			Name     string
 			User     string `default:"root"`
 			Password string `required:"true" env:"DBPassword"`
-			Port     uint   `default:"3306" json:",omitempty"`
-			SSL      bool   `default:"true" json:",omitempty"`
+			Port     uint   `default:"3306" json:"-"`
+			SSL      bool   `default:"true" json:"-"`
 		}{
 			Name:     "configor",
 			User:     "configor",
@@ -56,12 +57,14 @@ func generateDefaultConfig() testConfig {
 			SSL:      true,
 		},
 		Contacts: []struct {
-			Name  string
-			Email string `required:"true"`
+			Name   string
+			Email  string `required:"true"`
+			Active bool   `default:"true" json:"-"`
 		}{
 			{
-				Name:  "Jinzhu",
-				Email: "wosmvp@gmail.com",
+				Name:   "Jinzhu",
+				Email:  "wosmvp@gmail.com",
+				Active: true,
 			},
 		},
 		Anonymous: Anonymous{

--- a/utils.go
+++ b/utils.go
@@ -371,9 +371,6 @@ func (configor *Configor) load(config interface{}, watchMode bool, files ...stri
 		}
 	}
 
-	// process defaults
-	configor.processDefaults(config)
-
 	for _, file := range configFiles {
 		if configor.Config.Debug || configor.Config.Verbose {
 			fmt.Printf("Loading configurations from file '%v'...\n", file)
@@ -389,6 +386,9 @@ func (configor *Configor) load(config interface{}, watchMode bool, files ...stri
 	} else {
 		err = configor.processTags(config, prefix)
 	}
+
+	// process defaults
+	configor.processDefaults(config)
 
 	return err, true
 }


### PR DESCRIPTION
The default values are applied before the config is loaded. So the later loaded structs in the slice don't have default values.

https://github.com/jinzhu/configor/blob/1095c485b440be00e1ddf075f4acdbebc3d6e97e/utils.go#L375-L391

Loading the default values after parsing config files and env should fix this.

Related to #67.