### PR TITLE
fix bug that can't load default values for slice element

### DIFF
--- a/configor_test.go
+++ b/configor_test.go
@@ -681,3 +681,56 @@ func TestLoadNestedConfig(t *testing.T) {
 	adminConfig := MenuList{}
 	New(&Config{Verbose: true}).Load(&adminConfig, "admin.yml")
 }
+
+type SliceDefaultValueConfig struct {
+	Options []struct {
+		Name   string `yaml:"name" default:"xylonx" required:"true"`
+		Number int    `yaml:"number" default:"12" required:"true"`
+	} `yaml:"options"`
+}
+
+func TestSliceDefaultValue(t *testing.T) {
+	file, err := ioutil.TempFile("/tmp", "configor-test-default-value-for-slice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := new(SliceDefaultValueConfig)
+	err = Load(config, file.Name())
+	if err != nil {
+		t.Logf("load config from yaml error: %v", err)
+	}
+
+	rightConfig := SliceDefaultValueConfig{
+		Options: []struct {
+			Name   string `yaml:"name" default:"xylonx" required:"true"`
+			Number int    `yaml:"number" default:"12" required:"true"`
+		}{
+			{
+				Name:   "alice",
+				Number: 1,
+			},
+			{
+				Name:   "bob",
+				Number: 12,
+			},
+			{
+				Name:   "xylonx",
+				Number: 3,
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(rightConfig, config) {
+		t.Logf("load value: \n%v\nbut the right value is \n%v", *config, rightConfig)
+		t.Failed()
+	}
+}
+
+var sliceDefaultValueConfig = `
+options:
+  - name: alice
+    number: 1
+  - name: bob
+  - number: 3
+`

--- a/utils.go
+++ b/utils.go
@@ -371,9 +371,6 @@ func (configor *Configor) load(config interface{}, watchMode bool, files ...stri
 		}
 	}
 
-	// process defaults
-	configor.processDefaults(config)
-
 	for _, file := range configFiles {
 		if configor.Config.Debug || configor.Config.Verbose {
 			fmt.Printf("Loading configurations from file '%v'...\n", file)
@@ -383,6 +380,9 @@ func (configor *Configor) load(config interface{}, watchMode bool, files ...stri
 		}
 	}
 	configor.configModTimes = configModTimeMap
+
+	// process defaults
+	configor.processDefaults(config)
 
 	if prefix := configor.getENVPrefix(config); prefix == "-" {
 		err = configor.processTags(config)


### PR DESCRIPTION
it fix this bug by loading the default values after parsing config files and env and before parsing other tags.

Related to #68.

the problem of #68 is that it load default values after parsing other tags, which will crash the program when contains required:"true" tag.

I also add a test case named `TestSliceDefaultValue` for testing such situations.