### PR TITLE
Support load from fs.FS

### DIFF
--- a/configor_test.go
+++ b/configor_test.go
@@ -2,8 +2,8 @@ package configor
 
 import (
 	"bytes"
+	"embed"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -73,7 +73,7 @@ func generateDefaultConfig() testConfig {
 func TestLoadNormaltestConfig(t *testing.T) {
 	config := generateDefaultConfig()
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -96,7 +96,7 @@ func TestLoadtestConfigFromTomlWithExtension(t *testing.T) {
 	)
 
 	if err := toml.NewEncoder(&buffer).Encode(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor.toml"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor.toml"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(buffer.Bytes())
@@ -119,7 +119,7 @@ func TestLoadtestConfigFromTomlWithoutExtension(t *testing.T) {
 	)
 
 	if err := toml.NewEncoder(&buffer).Encode(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(buffer.Bytes())
@@ -142,7 +142,7 @@ func TestDefaultValue(t *testing.T) {
 	config.DB.SSL = false
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -164,7 +164,7 @@ func TestMissingRequiredValue(t *testing.T) {
 	config.DB.Password = ""
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -189,7 +189,7 @@ func TestUnmatchedKeyInTomltestConfigFile(t *testing.T) {
 	}
 	config := configFile{Name: "test", Test: "ATest"}
 
-	file, err := ioutil.TempFile("/tmp", "configor")
+	file, err := os.CreateTemp("/tmp", "configor")
 	if err != nil {
 		t.Fatal("Could not create temp file")
 	}
@@ -274,7 +274,7 @@ func TestUnmatchedKeyInYamltestConfigFile(t *testing.T) {
 	}
 	config := configFile{Name: "test", Test: "ATest"}
 
-	file, err := ioutil.TempFile("/tmp", "configor")
+	file, err := os.CreateTemp("/tmp", "configor")
 	if err != nil {
 		t.Fatal("Could not create temp file")
 	}
@@ -342,14 +342,14 @@ func TestLoadtestConfigurationByEnvironment(t *testing.T) {
 		APPName: "config2",
 	}
 
-	if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+	if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 		defer file.Close()
 		defer os.Remove(file.Name())
 		configBytes, _ := yaml.Marshal(config)
 		config2Bytes, _ := yaml.Marshal(config2)
-		ioutil.WriteFile(file.Name()+".yaml", configBytes, 0644)
+		os.WriteFile(file.Name()+".yaml", configBytes, 0644)
 		defer os.Remove(file.Name() + ".yaml")
-		ioutil.WriteFile(file.Name()+".production.yaml", config2Bytes, 0644)
+		os.WriteFile(file.Name()+".production.yaml", config2Bytes, 0644)
 		defer os.Remove(file.Name() + ".production.yaml")
 
 		var result testConfig
@@ -375,14 +375,14 @@ func TestLoadtestConfigurationByEnvironmentSetBytestConfig(t *testing.T) {
 		APPName: "production_config2",
 	}
 
-	if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+	if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 		defer file.Close()
 		defer os.Remove(file.Name())
 		configBytes, _ := yaml.Marshal(config)
 		config2Bytes, _ := yaml.Marshal(config2)
-		ioutil.WriteFile(file.Name()+".yaml", configBytes, 0644)
+		os.WriteFile(file.Name()+".yaml", configBytes, 0644)
 		defer os.Remove(file.Name() + ".yaml")
-		ioutil.WriteFile(file.Name()+".production.yaml", config2Bytes, 0644)
+		os.WriteFile(file.Name()+".production.yaml", config2Bytes, 0644)
 		defer os.Remove(file.Name() + ".production.yaml")
 
 		var result testConfig
@@ -407,7 +407,7 @@ func TestOverwritetestConfigurationWithEnvironmentWithDefaultPrefix(t *testing.T
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -435,7 +435,7 @@ func TestOverwritetestConfigurationWithEnvironment(t *testing.T) {
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -462,7 +462,7 @@ func TestOverwritetestConfigurationWithEnvironmentThatSetBytestConfig(t *testing
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -489,7 +489,7 @@ func TestResetPrefixToBlank(t *testing.T) {
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -516,7 +516,7 @@ func TestResetPrefixToBlank2(t *testing.T) {
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -543,7 +543,7 @@ func TestReadFromEnvironmentWithSpecifiedEnvName(t *testing.T) {
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -565,7 +565,7 @@ func TestAnonymousStruct(t *testing.T) {
 	config := generateDefaultConfig()
 
 	if bytes, err := json.Marshal(config); err == nil {
-		if file, err := ioutil.TempFile("/tmp", "configor"); err == nil {
+		if file, err := os.CreateTemp("/tmp", "configor"); err == nil {
 			defer file.Close()
 			defer os.Remove(file.Name())
 			file.Write(bytes)
@@ -680,4 +680,12 @@ type MenuList struct {
 func TestLoadNestedConfig(t *testing.T) {
 	adminConfig := MenuList{}
 	New(&Config{Verbose: true}).Load(&adminConfig, "admin.yml")
+}
+
+//go:embed admin.yml
+var fsysForAdminYaml embed.FS
+
+func TestLoadNestedConfigFromFS(t *testing.T) {
+	adminConfig := MenuList{}
+	New(&Config{Verbose: true}).LoadFromFS(&adminConfig, fsysForAdminYaml, "admin.yml")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/jinzhu/configor
 
-go 1.12
+go 1.17
 
 require (
-	github.com/BurntSushi/toml v0.3.1
-	gopkg.in/yaml.v2 v2.2.2
+	github.com/BurntSushi/toml v0.4.1
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/unmarshal_json_test.go
+++ b/unmarshal_json_test.go
@@ -2,7 +2,6 @@ package configor_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -20,7 +19,7 @@ func TestUnmatchedKeyInJsonConfigFile(t *testing.T) {
 	}
 	config := configFile{Name: "test", Test: "ATest"}
 
-	file, err := ioutil.TempFile("/tmp", "configor")
+	file, err := os.CreateTemp("/tmp", "configor")
 	if err != nil {
 		t.Fatal("Could not create temp file")
 	}


### PR DESCRIPTION
Related to: https://github.com/jinzhu/configor/issues/70

Changes:
* Upgrade deps
* Target go 1.17
* Add LoadFromFS to support loading config files from embed.FS
* Remove usages of ioutil since it has been deprecated
