### PR TITLE
fix: Load panics when trying to load a non primitive type field with a string inner type

### DIFF
--- a/configor_test.go
+++ b/configor_test.go
@@ -696,3 +696,24 @@ func TestLoad_FS(t *testing.T) {
 		t.Error("expected to have foo: bar in config")
 	}
 }
+
+func TestLoadConfigFromEnvWithFieldInnerTypeStringButRealTypeSomethingElse(t *testing.T) {
+	type myStringType string
+	type myTestConfig struct {
+		Name myStringType
+	}
+	var result myTestConfig
+	key := "MYTEST_NAME"
+	expected := "bob"
+	err := os.Setenv(key, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Unsetenv(key)
+	New(&Config{
+		ENVPrefix: "MYTEST",
+	}).Load(&result)
+	if string(result.Name) != expected {
+		t.Errorf("expected '%s' got '%s'", expected, result.Name)
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -307,7 +307,11 @@ func (configor *Configor) processTags(config interface{}, prefixes ...string) er
 						field.Set(reflect.ValueOf(true))
 					}
 				case reflect.String:
-					field.Set(reflect.ValueOf(value))
+					if field.Type() == reflect.TypeOf(value) {
+						field.Set(reflect.ValueOf(value))
+						break
+					}
+					fallthrough
 				default:
 					if err := yaml.Unmarshal([]byte(value), field.Addr().Interface()); err != nil {
 						return err


### PR DESCRIPTION
Hello everyone,

I recently stumbled across a bug when using this library, the following code panics:
```go
	type myStringType string
	type myTestConfig struct {
		Name myStringType
	}
	var result myTestConfig
	key := "MYTEST_NAME"
	expected := "bob"
	os.Setenv(key, expected)
	New(&Config{
		ENVPrefix: "MYTEST",
	}).Load(&result) // panic
```

This MR fixes this issue.