### PR TITLE
chore: use raw string () with regexp.MustCompile to avoid having to e…

### DIFF
--- a/configor.go
+++ b/configor.go
@@ -58,7 +58,7 @@ func New(config *Config) *Configor {
 	return &Configor{Config: config}
 }
 
-var testRegexp = regexp.MustCompile("_test|(\\.test$)")
+var testRegexp = regexp.MustCompile(`_test|(\.test$)`)
 
 // GetEnvironment get environment
 func (configor *Configor) GetEnvironment() string {


### PR DESCRIPTION
use raw string () with regexp.MustCompile to avoid having to escape twice