### PR TITLE
Bug fix: In auto-reload mode, the configuration fails to revert to th…

### DIFF
--- a/configor.go
+++ b/configor.go
@@ -85,7 +85,8 @@ func (configor *Configor) GetErrorOnUnmatchedKeys() bool {
 
 // Load will unmarshal configurations to struct from files that you provide
 func (configor *Configor) Load(config interface{}, files ...string) (err error) {
-	defaultValue := reflect.Indirect(reflect.ValueOf(config))
+	defaultValue := reflect.New(reflect.ValueOf(config).Elem().Type()).Elem()
+	defaultValue.Set(reflect.Indirect(reflect.ValueOf(config)))
 	if !defaultValue.CanAddr() {
 		return fmt.Errorf("Config %v should be addressable", config)
 	}


### PR DESCRIPTION
 In auto-reload mode, the configuration fails to revert to the default value when a configuration item is removed from the file.